### PR TITLE
Fix Deprecated BIF: erlang:now/0

### DIFF
--- a/apps/glot/src/logging/event_log_srv.erl
+++ b/apps/glot/src/logging/event_log_srv.erl
@@ -49,7 +49,7 @@ terminate(Reason, #state{file=File}) ->
 
 append(Data) ->
     Data2 = Data#{
-        timestamp => iso8601:format(now()),
+        timestamp => iso8601:format(os:timestamp()),
         pid => util:pid_to_binary(self())
     },
     gen_server:cast(?MODULE, {append, Data2}).

--- a/apps/glot/src/logging/http_log_srv.erl
+++ b/apps/glot/src/logging/http_log_srv.erl
@@ -49,7 +49,7 @@ terminate(Reason, #state{file=File}) ->
 
 append(Data) ->
     Data2 = Data#{
-        timestamp => iso8601:format(now()),
+        timestamp => iso8601:format(os:timestamp()),
         pid => util:pid_to_binary(self())
     },
     gen_server:cast(?MODULE, {append, Data2}).

--- a/apps/glot/src/models/snippet.erl
+++ b/apps/glot/src/models/snippet.erl
@@ -146,7 +146,7 @@ prepare_save(Data) ->
     ].
 
 prepare_update(Id, Rev, Data) ->
-    Now = iso8601:format(now()),
+    Now = iso8601:format(os:timestamp()),
     [
         {<<"_id">>, Id},
         {<<"_rev">>, Rev},

--- a/apps/glot/src/models/users.erl
+++ b/apps/glot/src/models/users.erl
@@ -37,7 +37,7 @@ delete(Id, Rev) ->
     user_srv:delete(Doc).
 
 prepare_save(Data) ->
-    Now = iso8601:format(now()),
+    Now = iso8601:format(os:timestamp()),
     [
         {<<"_id">>, identifier()},
         {<<"created">>, Now},
@@ -46,7 +46,7 @@ prepare_save(Data) ->
     ].
 
 prepare_update(Id, OldUser, Data) ->
-    Now = iso8601:format(now()),
+    Now = iso8601:format(os:timestamp()),
     [
         {<<"_id">>, Id},
         {<<"_rev">>, proplists:get_value(<<"_rev">>, OldUser)},

--- a/apps/glot/src/util.erl
+++ b/apps/glot/src/util.erl
@@ -35,7 +35,7 @@ pid_to_binary(Pid) ->
     list_to_binary(pid_to_list(Pid)).
 
 microseconds_since_epoch() ->
-    {Megasecs, Secs, Microsecs} = now(),
+    {Megasecs, Secs, Microsecs} = os:timestamp(),
     (Megasecs * 1000000 + Secs) * 1000000 + Microsecs.
 
 microseconds_to_timestamp(N) ->


### PR DESCRIPTION
Removes this warning:

```
===> Compiling glot
/glot-snippets/_build/default/lib/glot/src/util.erl:38: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

/glot-snippets/_build/default/lib/glot/src/models/snippet.erl:149: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

/glot-snippets/_build/default/lib/glot/src/models/users.erl:40: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
/glot-snippets/_build/default/lib/glot/src/models/users.erl:49: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

/glot-snippets/_build/default/lib/glot/src/logging/http_log_srv.erl:52: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

/glot-snippets/_build/default/lib/glot/src/logging/event_log_srv.erl:52: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

```
