### PR TITLE
Added Authorization to "access-control-allow-headers"

### DIFF
--- a/apps/glot/src/http/http_util.erl
+++ b/apps/glot/src/http/http_util.erl
@@ -76,7 +76,7 @@ add_cors_headers(Req, Methods) ->
     Headers = [
         {<<"access-control-allow-methods">>, join_methods(Methods)},
         {<<"access-control-allow-origin">>, <<"*">>},
-        {<<"access-control-allow-headers">>, <<"Content-Type">>}
+        {<<"access-control-allow-headers">>, <<"Authorization, Content-Type">>}
     ],
     set_headers(Headers, Req).
 


### PR DESCRIPTION
I was getting CORS errors in my Angular APP because the "Authorization" header was not being allowed.